### PR TITLE
Don't leak fds, and don't unset cloexec except/until needed

### DIFF
--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::process::{ProcessEvent, ProcessHandler};
+use std::os::unix::io::RawFd;
 use tokio::sync::mpsc::unbounded_channel;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, Span};
@@ -10,12 +11,13 @@ pub fn run_executable(
 	executable: &'static str,
 	args: Vec<String>,
 	env_vars: Vec<(String, String)>,
+	fds: Vec<RawFd>,
 ) {
 	let span_2 = span.clone();
 	let (tx, mut rx) = unbounded_channel::<ProcessEvent>();
 	tokio::spawn(
 		async move {
-			ProcessHandler::new(tx, &token).run(executable, args, env_vars, &span);
+			ProcessHandler::new(tx, &token).run(executable, args, env_vars, fds, &span);
 			while let Some(event) = rx.recv().await {
 				match event {
 					ProcessEvent::Started => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,21 +55,25 @@ async fn main() -> Result<()> {
 
 	let mut sockets = Vec::with_capacity(2);
 
+	let (env, fd) = comp::create_privileged_socket(&mut sockets, &env_vars)
+		.wrap_err("failed to create panel socket")?;
 	generic::run_executable(
 		token.child_token(),
 		info_span!(parent: None, "cosmic-panel"),
 		"cosmic-panel",
 		vec!["testing-panel".into()],
-		comp::create_privileged_socket(&mut sockets, &env_vars)
-			.wrap_err("failed to create panel socket")?,
+		env,
+		vec![fd],
 	);
+	let (env, fd) = comp::create_privileged_socket(&mut sockets, &env_vars)
+		.wrap_err("failed to create dock socket")?;
 	generic::run_executable(
 		token.child_token(),
 		info_span!(parent: None, "cosmic-panel dock"),
 		"cosmic-panel",
 		vec!["testing-dock".into()],
-		comp::create_privileged_socket(&mut sockets, &env_vars)
-			.wrap_err("failed to create dock socket")?,
+		env,
+		vec![fd],
 	);
 	socket_tx.send(sockets).unwrap();
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::process::{ExitStatus, Stdio};
+use color_eyre::eyre::{ContextCompat, Result, WrapErr};
+use nix::{fcntl, unistd};
+use std::{
+	os::unix::prelude::*,
+	process::{ExitStatus, Stdio},
+};
 use tokio::{
 	io::{AsyncBufReadExt, BufReader},
 	process::Command,
@@ -28,16 +33,24 @@ impl ProcessHandler {
 		}
 	}
 
+	// TODO: Use `OwnedFd` when stable
 	pub fn run(
 		self,
 		executable: impl ToString,
 		args: Vec<String>,
 		vars: Vec<(String, String)>,
+		fds: Vec<RawFd>,
 		span: &Span,
 	) {
 		let executable = executable.to_string();
 		tokio::spawn(
 			async move {
+				for fd in &fds {
+					if let Err(err) = mark_as_not_cloexec(fd) {
+						error!("failed to launch '{}': {}", executable, err);
+						return;
+					}
+				}
 				let mut child = match Command::new(&executable)
 					.args(&args)
 					.stdin(Stdio::null())
@@ -58,6 +71,9 @@ impl ProcessHandler {
 						return;
 					}
 				};
+				for fd in &fds {
+					let _ = unistd::close(*fd);
+				}
 				let mut stdout = BufReader::new(child.stdout.take().unwrap()).lines();
 				let mut stderr = BufReader::new(child.stderr.take().unwrap()).lines();
 				std::mem::drop(self.tx.send(ProcessEvent::Started));
@@ -115,4 +131,19 @@ impl ProcessHandler {
 			.instrument(span.clone()),
 		);
 	}
+}
+
+fn mark_as_not_cloexec(file: &impl AsRawFd) -> Result<()> {
+	let raw_fd = file.as_raw_fd();
+	let fd_flags = fcntl::FdFlag::from_bits(
+		fcntl::fcntl(raw_fd, fcntl::FcntlArg::F_GETFD)
+			.wrap_err("failed to get GETFD value of stream")?,
+	)
+	.wrap_err("failed to get fd flags from file")?;
+	fcntl::fcntl(
+		raw_fd,
+		fcntl::FcntlArg::F_SETFD(fd_flags.difference(fcntl::FdFlag::FD_CLOEXEC)),
+	)
+	.wrap_err("failed to set CLOEXEC on file")?;
+	Ok(())
 }


### PR DESCRIPTION
This may still leak fds in some error cases. That can be solved by using `OwnedFd` when the next Rust stable releases.