### PR TITLE
Don't log output of cosmic-comp/cosmic-panel, log panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "futures-util",
  "launch-pad",
  "libc",
+ "log-panics",
  "nix 0.25.0",
  "scopeguard",
  "sendfd",
@@ -482,6 +483,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "log-panics"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
+dependencies = [
+ "backtrace",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ color-eyre = "0.6"
 futures-util = "0.3"
 launch-pad = { git = "https://github.com/pop-os/launch-pad" }
 libc = "0.2"
+log-panics = { version = "2", features = ["with-backtrace"] }
 nix = { version = "0.25", features = ["fs"], default-features = false }
 scopeguard = "1"
 sendfd = { version = "0.4", features = ["tokio"] }


### PR DESCRIPTION
It is better to have `cosmic-comp` and `cosmic-panel` log to journald themselves.

Having panics logged should be helpful if panics ever occur.

See https://github.com/pop-os/cosmic-comp/pull/60 and https://github.com/pop-os/cosmic-panel/pull/20.

Though it is useful for us to log when the subprocess terminates with and exit status or signal. https://github.com/pop-os/launch-pad/pull/3 handles this.