### PR TITLE
Start `cosmic-osd`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,9 @@ async fn main() -> Result<()> {
 	let span = info_span!(parent: None, "cosmic-workspaces");
 	start_component("cosmic-workspaces", span, &process_manager, &env_vars).await;
 
+	let span = info_span!(parent: None, "cosmic-osd");
+	start_component("cosmic-osd", span, &process_manager, &env_vars).await;
+
 	let span = info_span!(parent: None, "cosmic-bg");
 	start_component("cosmic-bg", span, &process_manager, &env_vars).await;
 


### PR DESCRIPTION
Seems this had been removed in a4a791e.

This makes polkit dialogs show, though the Iced implementation of those could use improvement.