### PR TITLE
Allow xcb QT_QPA_PLATFORM as a fallback

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -29,7 +29,7 @@ export XCURSOR_THEME="${XCURSOR_THEME:=Pop}"
 export _JAVA_AWT_WM_NONREPARENTING=1
 export GDK_BACKEND=wayland,x11
 export MOZ_ENABLE_WAYLAND=1
-export QT_QPA_PLATFORM="wayland;x11"
+export QT_QPA_PLATFORM="wayland;xcb"
 
 # import environment variables from the login manager
 systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP

--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -29,7 +29,7 @@ export XCURSOR_THEME="${XCURSOR_THEME:=Pop}"
 export _JAVA_AWT_WM_NONREPARENTING=1
 export GDK_BACKEND=wayland,x11
 export MOZ_ENABLE_WAYLAND=1
-export QT_QPA_PLATFORM=wayland
+export QT_QPA_PLATFORM="wayland;x11"
 
 # import environment variables from the login manager
 systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP


### PR DESCRIPTION
Untested, but this should allow the usage of Xwayland by QT, e.g. if the wayland-plugin is simply not installed or not available for some other reason, while still preferring wayland.