### PR TITLE
fix: use preferred SHELL in login shell mode

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # From: https://people.debian.org/~mpitt/systemd.conf-2016-graphical-session.pdf
 
 # robustness: if the previous graphical session left some failed units,
@@ -14,13 +16,14 @@ for unit in $(systemctl --user --no-legend --state=failed --plain list-units | c
     done
 done
 
-# /etc/profile contains a lot of important environment variables
-source /etc/profile
-
-# load user's profile if it exists
-if [ -n "${HOME}" -a -f "${HOME}/.profile" ]
-then
-    source "${HOME}/.profile"
+# use the user's preferred shell to acquire environment variables
+# see: https://github.com/pop-os/cosmic-session/issues/23
+if [ -n "${SHELL}" ]; then
+    # --in-login-shell: our flag to indicate that we don't need to recurse any further
+    if [ "${1}" != "--in-login-shell" ]; then
+        # `exec -l`: like `login`, prefixes $SHELL with a hyphen to start a login shell
+        exec bash -c "exec -l '${SHELL}' -c '${0} --in-login-shell'"
+    fi
 fi
 
 export XDG_CURRENT_DESKTOP="${XDG_CURRENT_DESKTOP:=COSMIC}"


### PR DESCRIPTION
- fixes #23 
- inspired by long-established behaviour in GNOME (GPL-2): https://gitlab.gnome.org/GNOME/gnome-session/-/blob/998ed1d8ee2ff5396583c284230648625b4103e5/gnome-session/gnome-session.in#L10
- tested with a new user account with SHELL=/usr/bin/bash
- tested with existing user account with SHELL=/usr/bin/nu