### PR TITLE
feat: set XDG_DESKTOP_TYPE=wayland after cosmic-comp is ready and just before graphical-session.target

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use tokio::{
 		mpsc::{self, Receiver, Sender},
 		oneshot, Mutex,
 	},
-	time::{sleep, Duration},
+	time::Duration,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{metadata::LevelFilter, Instrument};
@@ -112,8 +112,6 @@ async fn start(
 		session_tx,
 	)
 	.wrap_err("failed to start compositor")?;
-
-	sleep(Duration::from_millis(2000)).await;
 
 	let mut env_vars = env_rx
 		.await

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -2,6 +2,13 @@
 
 use std::process::{Command, Stdio};
 
+pub async fn set_systemd_environment(key: &str, value: &str) {
+	run_optional_command(
+		"systemctl",
+		&["--user", "set-environment", &format!("{key}={value}")],
+	)
+}
+
 pub async fn start_systemd_target() {
 	run_optional_command(
 		"systemctl",


### PR DESCRIPTION
~- hardcode XDG_SESSION_TYPE=wayland, because otherwise it defaults to tty on my system, which means the "about" page in cosmic-settings says "tty" instead of "wayland" (and COSMIC doesn't need to support/advertise any other value other than wayland)~
~- hardcode XDG_CURRENT_DESKTOP=cosmic, to improve the integration with xdg-desktop-portal and xdg-desktop-portal-cosmic (one step towards allowing `xdg-desktop-portal` to start `xdg-desktop-portal-cosmic` on-demand rather than explicitly starting it here in `cosmic-session`)~
~- modify `start-cosmic` so that it checks for `systemctl` before calling it (helping to make systemd optional)~

- per https://github.com/pop-os/cosmic-session/pull/31#issuecomment-1883016009
- re-order start sequence so that systemd is notified that we've reached graphical-session.target *after* `cosmic-comp` is ready
- set XDG_SESSION_TYPE=wayland for new/future processes after `cosmic-comp` is ready and before notifying systemd about graphical-session.target
- tested and confirmed that this results in "Wayland" showing up as expected in the "About" page in `cosmic-settings`, rather than "Tty"