### PR TITLE
fix: check before using `systemctl`

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -2,17 +2,19 @@
 
 # From: https://people.debian.org/~mpitt/systemd.conf-2016-graphical-session.pdf
 
-# robustness: if the previous graphical session left some failed units,
-# reset them so that they don't break this startup
-for unit in $(systemctl --user --no-legend --state=failed --plain list-units | cut -f1 -d' '); do
-    partof="$(systemctl --user show -p PartOf --value "$unit")"
-    for target in cosmic-session.target graphical-session.target; do
-        if [ "$partof" = "$target" ]; then
-            systemctl --user reset-failed "$unit"
-            break
-        fi
+if command -v systemctl >/dev/null; then
+    # robustness: if the previous graphical session left some failed units,
+    # reset them so that they don't break this startup
+    for unit in $(systemctl --user --no-legend --state=failed --plain list-units | cut -f1 -d' '); do
+        partof="$(systemctl --user show -p PartOf --value "$unit")"
+        for target in cosmic-session.target graphical-session.target; do
+            if [ "$partof" = "$target" ]; then
+                systemctl --user reset-failed "$unit"
+                break
+            fi
+        done
     done
-done
+fi
 
 # /etc/profile contains a lot of important environment variables
 source /etc/profile
@@ -31,9 +33,10 @@ export GDK_BACKEND=wayland,x11
 export MOZ_ENABLE_WAYLAND=1
 export QT_QPA_PLATFORM="wayland;xcb"
 
-# import environment variables from the login manager
-systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
-
+if command -v systemctl >/dev/null; then
+    # set environment variables for new units started by user service manager
+    systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
+fi
 # Run cosmic-session
 if [[ -z "${DBUS_SESSION_BUS_ADDRESS}" ]]; then
     exec /usr/bin/dbus-run-session -- /usr/bin/cosmic-session


### PR DESCRIPTION
- extract out systemd-specific changes from https://github.com/pop-os/cosmic-session/pull/31
- this checks for `systemctl` before calling it, which should make systemd optional for this script