### PR TITLE
fix: allow calls for systemd graphical target to fail

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,15 +113,13 @@ async fn start(
 	)
 	.wrap_err("failed to start compositor")?;
 	sleep(Duration::from_millis(2000)).await;
-	systemd::start_systemd_target()
-		.await
-		.wrap_err("failed to start systemd target")?;
+
+	systemd::start_systemd_target().await;
 	// Always stop the target when the process exits or panics.
 	scopeguard::defer! {
-		if let Err(error) = systemd::stop_systemd_target() {
-			error!("failed to stop systemd target: {:?}", error);
-		}
+		systemd::stop_systemd_target();
 	}
+
 	let env_vars = env_rx
 		.await
 		.expect("failed to receive environmental variables")


### PR DESCRIPTION
- extracted out common `std::process::Command` work, and made that function swallow errors rather than return them or panic (because we want to keep systemd optional)
- pass a null stdin to `std::process::Command`, because it's allegedly faster to skip inheriting the parent's stdin (and it's not our intention to allow this inheritance anyway)
- switch from `.spawn()` to `.status()` so that we can at least find out if `systemctl` accepted our calls (mostly for diagnostic purposes)
- pass `--no-block` to `systemctl` when starting/stopping the graphical target, because we care mostly that we called into systemd successfully, not what happens inside systemd after that

in all testing below, the session and compositor continue to launch as normal:
- tested the happy path, and that `systemctl --user status cosmic-session.target` shows it is active
- tested with `systemctl-foo` as the hardcoded command, to confirm that that the `Err` branch results in the expected logs, and that `systemctl --user status cosmic-session.target` shows it is inactive
- tested with `cosmic-session-foo.target` as the hardcoded target, to confirm that that the non-zero exit status code branch results in the expected logs, and that `systemctl --user status cosmic-session.target` shows it is inactive