### PR TITLE
Add support for ssh-agent if that is installed on the system

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -40,9 +40,15 @@ if command -v systemctl >/dev/null; then
     # set environment variables for new units started by user service manager
     systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 fi
+
+SSH_AGENT=""
+if [ -x /usr/bin/ssh-agent ]; then
+  SSH_AGENT=/usr/bin/ssh-agent
+fi
+
 # Run cosmic-session
 if [[ -z "${DBUS_SESSION_BUS_ADDRESS}" ]]; then
-    exec /usr/bin/dbus-run-session -- /usr/bin/cosmic-session
+    exec /usr/bin/dbus-run-session -- $SSH_AGENT /usr/bin/cosmic-session
 else
-    exec /usr/bin/cosmic-session
+    exec $SSH_AGENT /usr/bin/cosmic-session
 fi


### PR DESCRIPTION
This patch ensures we run an ssh-agent if it is found on the system. 
Note that $SSH_AGENT is deliberately unquoted to expand to nothing if no agent is found on the system