### PR TITLE
fix: remove MOZ_ENABLE_WAYLAND=1

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -33,7 +33,6 @@ export XDG_SESSION_TYPE="${XDG_SESSION_TYPE:=wayland}"
 export XCURSOR_THEME="${XCURSOR_THEME:=Pop}"
 export _JAVA_AWT_WM_NONREPARENTING=1
 export GDK_BACKEND=wayland,x11
-export MOZ_ENABLE_WAYLAND=1
 export QT_QPA_PLATFORM="wayland;xcb"
 
 if command -v systemctl >/dev/null; then


### PR DESCRIPTION
We no longer need this environment variable set, as Firefox comes with wayland enabled by default since version 121 (source: https://wiki.archlinux.org/title/firefox)