### PR TITLE
Fix building and running on systems without systemd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ zbus_systemd = { version = "0.25600.0", optional = true, features = [
 ] }
 tokio-util = "0.7"
 tracing = "0.1"
-tracing-journald = "0.3"
+tracing-journald = { version = "0.3", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 zbus = { version = "4.3.0", default-features = false, features = ["tokio"] }
 cosmic-notifications-util = { git = "https://github.com/pop-os/cosmic-notifications" }
 
 [features]
-systemd = ["dep:zbus_systemd"]
+systemd = ["dep:zbus_systemd", "dep:tracing-journald"]
 default = ["systemd"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,10 @@ const XDP_COSMIC: Option<&'static str> = option_env!("XDP_COSMIC");
 async fn main() -> Result<()> {
 	color_eyre::install().wrap_err("failed to install color_eyre error handler")?;
 
-	tracing_subscriber::registry()
-		.with(tracing_journald::layer().wrap_err("failed to connect to journald")?)
+	let trace = tracing_subscriber::registry();
+	#[cfg(feature = "systemd")]
+	let trace = trace.with(tracing_journald::layer().wrap_err("failed to connect to journald")?);
+	trace
 		.with(fmt::layer())
 		.with(
 			EnvFilter::builder()


### PR DESCRIPTION
Addresses: https://github.com/pop-os/cosmic-session/issues/51

Currently trying to build without the `systemd` feature causes compile time errors. The first commit in this PR simply fixes those.

The seconds commit turns `tracing-journald` into an optional dependency which is only included when building with the `systemd` feature.

The third commit removes the runtime panic that occurs when  `journald` is not available on a system, falling back to a default and providing a warning instead of a hard crash. This is useful on distros like Artix or Devuan where many features of systemd are available (dbus, logind), such that building with the `systemd` feature is preferable, but journald is not present.