### PR TITLE
start-cosmic: Set QT auto scaling env variables

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -35,6 +35,8 @@ export _JAVA_AWT_WM_NONREPARENTING=1
 export GDK_BACKEND=wayland,x11
 export MOZ_ENABLE_WAYLAND=1
 export QT_QPA_PLATFORM="wayland;xcb"
+export QT_AUTO_SCREEN_SCALE_FACTOR=1
+export QT_ENABLE_HIGHDPI_SCALING=1
 
 if command -v systemctl >/dev/null; then
     # set environment variables for new units started by user service manager


### PR DESCRIPTION
This makes sure together with our XSettings implementation in cosmic-comp, that QT apps running on their xcb backend will react to the DPI values we are setting by changing their internal scaling.

~~Depends on https://github.com/pop-os/cosmic-comp/pull/779 being merged first.~~ cosmic-comp changes merged.