### PR TITLE
Launch `cosmic-idle`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Depends:
   cosmic-files,
   cosmic-greeter,
   cosmic-icons,
+  cosmic-idle,
   cosmic-launcher,
   cosmic-notifications,
   cosmic-osd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,6 +322,17 @@ async fn start(
 	)
 	.await;
 
+	let span = info_span!(parent: None, "cosmic-idle");
+	start_component(
+		"cosmic-idle",
+		span,
+		&process_manager,
+		&env_vars,
+		&socket_tx,
+		Vec::new(),
+	)
+	.await;
+
 	let span = info_span!(parent: None, "xdg-desktop-portal-cosmic");
 	let mut sockets = Vec::with_capacity(1);
 	let extra_env = Vec::with_capacity(1);


### PR DESCRIPTION
https://github.com/pop-os/cosmic-settings/pull/704 should be merged first, to have a way to control this.

We may also want to change the defaults in https://github.com/pop-os/cosmic-idle/blob/master/cosmic-idle-config/src/lib.rs before making it start by default.