### PR TITLE
make xdg-desktop-portal-cosmic path non fixed to libexec

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,18 @@ target := if debug == '1' { 'debug' } else { 'release' }
 vendor_args := if vendor == '1' { '--frozen --offline' } else { '' }
 debug_args := if debug == '1' { '' } else { '--release' }
 cargo_args := vendor_args + ' ' + debug_args
-xdp_cosmic := '/usr/libexec/xdg-desktop-portal-cosmic'
+
+xdp_cosmic := `
+if [ -f "/usr/libexec/xdg-desktop-portal-cosmic" ]; then
+    echo "/usr/libexec/xdg-desktop-portal-cosmic"
+elif [ -f "/usr/lib/xdg-desktop-portal-cosmic" ]; then
+    echo "/usr/lib/xdg-desktop-portal-cosmic"
+else
+    echo "Error: xdg-desktop-portal-cosmic not found in /usr/libexec or /usr/lib" >&2
+    exit 1
+fi
+`
+
 
 bindir := prefix + '/bin'
 systemddir := prefix + '/lib/systemd/user'


### PR DESCRIPTION
arch and other dists dont use libexec