### PR TITLE
fix: Set `XDG_CURRENT_DESKTOP` to `cosmic` instead of `COSMIC`

### DIFF
--- a/data/cosmic.desktop
+++ b/data/cosmic.desktop
@@ -3,4 +3,4 @@ Name=COSMIC
 Comment=This session logs you into the COSMIC desktop
 Exec=/usr/bin/start-cosmic
 Type=Application
-DesktopNames=COSMIC
+DesktopNames=cosmic

--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -28,7 +28,7 @@ if [ -n "${SHELL}" ]; then
     fi
 fi
 
-export XDG_CURRENT_DESKTOP="${XDG_CURRENT_DESKTOP:=COSMIC}"
+export XDG_CURRENT_DESKTOP="${XDG_CURRENT_DESKTOP:=cosmic}"
 export XDG_SESSION_TYPE="${XDG_SESSION_TYPE:=wayland}"
 export XCURSOR_THEME="${XCURSOR_THEME:=Cosmic}"
 export _JAVA_AWT_WM_NONREPARENTING=1

--- a/src/main.rs
+++ b/src/main.rs
@@ -346,7 +346,7 @@ async fn start(
 	)
 	.await;
 
-	if env::var("XDG_CURRENT_DESKTOP").as_deref() == Ok("COSMIC") {
+	if env::var("XDG_CURRENT_DESKTOP").as_deref() == Ok("cosmic") {
 		let span = info_span!(parent: None, "xdg-desktop-portal-cosmic");
 		let mut sockets = Vec::with_capacity(1);
 		let extra_env = Vec::with_capacity(1);


### PR DESCRIPTION
`XDG_CURRENT_DESKTOP` environment variable is expected to have a lower case value. One of purposes of that variable is determining the XDG portal to run and an upper-case value breaks the mechanism. The main visible symptome of the incorrect value is broken screen sharing and cosmic-screenshot showing the following error:

```
failed to send screenshot request: Zbus(MethodError(OwnedErrorName([...]
```

Overwriting that variable with `cosmic` is reported as a workaround by people facing the issue.[0][1] Using it in `start-cosmic` fixes the problem entirely.

Fixes pop-os/xdg-desktop-portal-cosmic#93

[0] https://aur.archlinux.org/packages/cosmic-screenshot-git#comment-980452
[1] https://github.com/pop-os/cosmic-screenshot/issues/3