### PR TITLE
session: Add custom dconf profile

### DIFF
--- a/data/dconf/profile/cosmic
+++ b/data/dconf/profile/cosmic
@@ -1,0 +1,2 @@
+user-db:cosmic
+user-db:user

--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -37,6 +37,7 @@ export MOZ_ENABLE_WAYLAND=1
 export QT_QPA_PLATFORM="wayland;xcb"
 export QT_AUTO_SCREEN_SCALE_FACTOR=1
 export QT_ENABLE_HIGHDPI_SCALING=1
+export DCONF_PROFILE=cosmic
 
 if command -v systemctl >/dev/null; then
     # set environment variables for new units started by user service manager

--- a/debian/cosmic-session.install
+++ b/debian/cosmic-session.install
@@ -1,0 +1,1 @@
+data/dconf/profile/cosmic /usr/share/dconf/profile/


### PR DESCRIPTION
This causes the cosmic-session to have a separate writable dconf-database (while still inheriting the default user database).

This will (partially) prevent issues such as https://github.com/pop-os/cosmic-epoch/issues/1174 in the future, as other desktops won't pick up cosmic's dconf profile.

**Note to packagers**: The dconf profile is highly specific to POP!_OS, which it why it isn't picked up by our `Justfile`. You are highly encouraged to provide your own.

Pop!_OS doesn't have a default user-profile, which means the profile defaults to `user-db:user` (see [man 7 dconf](https://man.archlinux.org/man/dconf.7.en#PROFILES)). The contents of the cosmic profile should be:

```
user-db:cosmic
[the contents of /usr/share/dconf/profile/user of your distro]
```

Failing to provide a cosmic profile file will cause the session to have a read-only dconf store.