### PR TITLE
build: Make dconf profile path explicit and configurable

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -11,6 +11,7 @@ debug_args := if debug == '1' { '' } else { '--release' }
 cargo_args := vendor_args + ' ' + debug_args
 xdp_cosmic := '/usr/libexec/xdg-desktop-portal-cosmic'
 orca := '/usr/bin/orca'
+cosmic_dconf_profile := '/usr/share/dconf/profile/cosmic'
 
 bindir := prefix + '/bin'
 systemddir := prefix + '/lib/systemd/user'
@@ -29,6 +30,7 @@ install:
 
 	# session start script
 	install -Dm0755 data/start-cosmic {{bindir}}/start-cosmic
+	sed -i "s|DCONF_PROFILE=cosmic|DCONF_PROFILE={{cosmic_dconf_profile}}|" {{bindir}}/start-cosmic
 	
 	# systemd target
 	install -Dm0644 data/cosmic-session.target {{systemddir}}/cosmic-session.target


### PR DESCRIPTION
Addresses the problem pointed out here: https://github.com/pop-os/cosmic-session/pull/90#issuecomment-2521418496

Apparently dconf doesn't by default lookup `/usr/share/` and just `/etc/`. This oversight causes our session on Pop!_OS to now have a read-only profile...

Given other distributions might run into similar problems, if they don't want to install the profile to `/etc`, I also made it configurable at install time.