### PR TITLE
start-cosmic: Import DCONF_PROFILE into systemd user environment

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -40,7 +40,7 @@ export DCONF_PROFILE=cosmic
 
 if command -v systemctl >/dev/null; then
     # set environment variables for new units started by user service manager
-    systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
+    systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DCONF_PROFILE
 fi
 # Run cosmic-session
 if [[ -z "${DBUS_SESSION_BUS_ADDRESS}" ]]; then


### PR DESCRIPTION
Lets see if this fixes gsettings sync into flatpaks.
(Presumably the gtk-portal didn't get the memo of our custom dconf profile otherwise.)