### PR TITLE
Install dconf profile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -41,6 +41,9 @@ install:
 	# mimeapps
 	install -Dm0644 data/cosmic-mimeapps.list {{applicationdir}}/cosmic-mimeapps.list
 
+	# dconf profile
+	install -Dm644 data/dconf/profile/cosmic {{cosmic_dconf_profile}}
+
 clean_vendor:
 	rm -rf vendor vendor.tar .cargo/config
 

--- a/Justfile
+++ b/Justfile
@@ -11,7 +11,7 @@ debug_args := if debug == '1' { '' } else { '--release' }
 cargo_args := vendor_args + ' ' + debug_args
 xdp_cosmic := '/usr/libexec/xdg-desktop-portal-cosmic'
 orca := '/usr/bin/orca'
-cosmic_dconf_profile := '/usr/share/dconf/profile/cosmic'
+cosmic_dconf_profile := prefix + '/share/dconf/profile/cosmic'
 
 bindir := prefix + '/bin'
 systemddir := prefix + '/lib/systemd/user'


### PR DESCRIPTION
This wasn't being installed by the justfile, so distros using the
justfile for packaging weren't properly installing the dconf profile.

Fixes https://gitlab.alpinelinux.org/alpine/aports/-/issues/17056