### PR TITLE
fix: ignore error when starting service

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -670,5 +670,11 @@ async fn start_component(
 				.with_fds(move || fds),
 		)
 		.await
-		.unwrap_or_else(|_| panic!("failed to start {}", cmd));
+		.unwrap_or_else(|err| {
+			let stderr_span = stderr_span.clone();
+			async move {
+				error!("failed to start {}: {}", cmd, err);
+			}
+			.instrument(stderr_span)
+		});
 }


### PR DESCRIPTION
Resolves #93.
Related: #83.

This PR is based on [this comment](https://github.com/pop-os/cosmic-session/issues/83#issuecomment-2823798796). It simply changes the behavior when fail to launch service from panic to just logging to the stderr.