### PR TITLE
fix: Allow to build with `autostart` and without `systemd` feature 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: test
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+
+      - name: Check
+        run: cargo hack check --feature-powerset
+
+      - name: Build
+        run: cargo hack build --feature-powerset
+
+      - name: Test
+        env:
+          RUST_BACKTRACE: full
+        run: cargo hack test --feature-powerset

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,9 @@ use std::{
 	os::fd::{AsRawFd, OwnedFd},
 	sync::Arc,
 };
+use systemd::is_systemd_used;
 #[cfg(feature = "systemd")]
-use systemd::{get_systemd_env, is_systemd_used, spawn_scope};
+use systemd::{get_systemd_env, spawn_scope};
 use tokio::{
 	net::UnixStream,
 	sync::{

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -52,9 +52,14 @@ pub fn stop_systemd_target() {
 
 /// Determine if systemd is used as the init system. This should work on all
 /// linux distributions.
+#[cfg(feature = "systemd")]
 pub fn is_systemd_used() -> &'static bool {
 	static IS_SYSTEMD_USED: OnceLock<bool> = OnceLock::new();
 	IS_SYSTEMD_USED.get_or_init(|| Path::new("/run/systemd/system").exists())
+}
+#[cfg(not(feature = "systemd"))]
+pub fn is_systemd_used() -> &'static bool {
+	&false
 }
 
 #[cfg(feature = "systemd")]


### PR DESCRIPTION
Before this change, import of `systemd::is_systemd_used` was hidden behind `cfg(feature = "systemd")` predicate. But that function is expected to be present in the autostart block even if `systemd` feature
is disabled.

Fix that by importing `is_systemd_used` unconditionally.

Provide an implementation of `is_systemd_used` for `cfg(not(feature = "systemd"))` which just returns `false`.

Fixes: #136