### PR TITLE
Start GNOME Keyring as part of session

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -48,3 +48,15 @@ if [[ -z "${DBUS_SESSION_BUS_ADDRESS}" ]]; then
 else
     exec /usr/bin/cosmic-session
 fi
+
+# Start gnome keyring components if the daemon is active
+if systemctl is-active --user --quiet gnome-keyring-daemon.service; then
+    # Start ssh component
+    /usr/bin/gnome-keyring-daemon --start --components=ssh
+
+    # start secrets component
+    /usr/bin/gnome-keyring-daemon --start --components=secrets
+
+    # start pkcs11 component
+    /usr/bin/gnome-keyring-daemon --start --components=pkcs11
+fi


### PR DESCRIPTION
As discussed in [Fedora Discussions](https://discussion.fedoraproject.org/t/gnome-keyring-on-cosmic/161243) and in [#cosmic:fedoraproject.org](https://matrix.to/#/#cosmic:fedoraproject.org), it is recommended to start GNOME Keyring as part of the Cosmic session.

While there is an [open PR for Fedora](https://src.fedoraproject.org/rpms/gnome-keyring/pull-request/13) to enable the keyring components, it is unlikely to be merged since it diverges from upstream. Moreover, upstream is not expected to support this behavior, and future changes (such as Cosmic adopting a different keyring or implementing its own?) could introduce compatibility issues.

With this PR, Cosmic will properly handle GNOME Keyring initialization itself.

**Summary of changes:**  
- Updated the session start script to ensure GNOME Keyring integration.
- The script now:
  - Checks if `gnome-keyring-daemon` is already running.
  - If so, activates the three key components:
    - `ssh`
    - `secrets`
    - `pkcs11`
- The commands used to launch these components are consistent with the upstream [daemon .desktop files](https://gitlab.gnome.org/GNOME/gnome-keyring/-/tree/main/daemon), which are designed for automatic startup via `xdg-autostart`.

This approach ensures GNOME Keyring is correctly initialized in Cosmic sessions without deviating from upstream's intended behavior.
