### PR TITLE
feat: syslog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-words",
+ "syslog-tracing",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1523,6 +1524,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "syslog-tracing"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d349bc2df408b4bf656709a29643641cef7f1795d708f88b105c626a8f64f6e4"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ zbus_systemd = { version = "0.25701.0", optional = true, features = [
 tokio-util = "0.7"
 tracing = "0.1"
 tracing-journald = { version = "0.3", optional = true }
+syslog-tracing = { version = "0.3", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 zbus = { version = "5.10.0", default-features = false, features = ["tokio"] }
 cosmic-notifications-util = { git = "https://github.com/pop-os/cosmic-notifications" }
@@ -51,6 +52,7 @@ logind-zbus = { version = "5.3.2", optional = true }
 
 [features]
 systemd = ["dep:zbus_systemd", "dep:tracing-journald"]
+syslog = ["dep:syslog-tracing"]
 logind = ["systemd", "logind-zbus"]
 default = ["logind"]
 autostart = ["dep:shell-words", "dep:dirs", "dep:freedesktop-desktop-entry"]


### PR DESCRIPTION
Adds syslog support for non-systemd distros. The feature is disabled by default.
If both `systemd` and `syslog` features are enabled it will prefer to use `journald` and fallback to `syslog` in case of a `journald` init error.

Needed this to troubleshoot performance issues on PostmarketOS.

Tested manually on PostmarketOS with default features + `syslog`.