### PR TITLE
Revert: session: Add custom dconf profile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,6 @@ vendor_args := if vendor == '1' { '--frozen --offline' } else { '' }
 debug_args := if debug == '1' { '' } else { '--release' }
 cargo_args := vendor_args + ' ' + debug_args
 orca := '/usr/bin/orca'
-cosmic_dconf_profile := prefix + '/share/dconf/profile/cosmic'
 
 bindir := rootdir / prefix + '/bin'
 systemddir := rootdir / prefix + '/lib/systemd/user'
@@ -24,13 +23,11 @@ build:
 
 # Installs files into the system
 install:
-	echo {{cosmic_dconf_profile}}
 	# main binary
 	install -Dm0755 {{cargo-target-dir}}/release/cosmic-session {{bindir}}/cosmic-session
 
 	# session start script
 	install -Dm0755 data/start-cosmic {{bindir}}/start-cosmic
-	sed -i "s|DCONF_PROFILE=cosmic|DCONF_PROFILE={{cosmic_dconf_profile}}|" {{bindir}}/start-cosmic
 
 	# systemd target
 	install -Dm0644 data/cosmic-session.target {{systemddir}}/cosmic-session.target
@@ -40,9 +37,6 @@ install:
 
 	# mimeapps
 	install -Dm0644 data/cosmic-mimeapps.list {{applicationdir}}/cosmic-mimeapps.list
-
-	# dconf profile
-	install -Dm644 data/dconf/profile/cosmic {{rootdir}}/{{cosmic_dconf_profile}}
 
 clean_vendor:
 	rm -rf vendor vendor.tar .cargo/config

--- a/data/dconf/profile/cosmic
+++ b/data/dconf/profile/cosmic
@@ -1,2 +1,0 @@
-user-db:cosmic
-user-db:user

--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -36,11 +36,10 @@ export MOZ_ENABLE_WAYLAND=1
 export QT_QPA_PLATFORM="wayland;xcb"
 export QT_AUTO_SCREEN_SCALE_FACTOR=1
 export QT_ENABLE_HIGHDPI_SCALING=1
-export DCONF_PROFILE=cosmic
 
 if command -v systemctl >/dev/null; then
     # set environment variables for new units started by user service manager
-    systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DCONF_PROFILE
+    systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP
 fi
 
 # Start gnome keyring components if the daemon is active


### PR DESCRIPTION
This pull request reverts https://github.com/pop-os/cosmic-session/pull/90.

Setting a custom profile for the COSMIC session causes that all apps launched in it save their settings into this custom profile rather than the into main user profile, so these settings are lost when the user logs in into a different desktop environment.

Since the custom `gtk.css` is [cleaned up on exit](https://github.com/pop-os/cosmic-settings-daemon/commit/f079ab7f98132787de385934915547f333dfbddc), and the GTK theme override is an optional feature, it should be safe to use the main dconf profile.

To avoid overwriting the `icon-theme` and `button-layout` GSettings properties on login by default, I proposed two solutions:
- https://github.com/pop-os/cosmic-settings-daemon/pull/116
- https://github.com/pop-os/cosmic-settings-daemon/pull/117