### PR TITLE
Add SSH_AUTH_SOCK to systemd import-environment

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -38,11 +38,6 @@ export QT_AUTO_SCREEN_SCALE_FACTOR=1
 export QT_ENABLE_HIGHDPI_SCALING=1
 export DCONF_PROFILE=cosmic
 
-if command -v systemctl >/dev/null; then
-    # set environment variables for new units started by user service manager
-    systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DCONF_PROFILE
-fi
-
 # Start gnome keyring components if the daemon is active
 # -> check if /run/user/$UID/keyring exists
 if [ -d "/run/user/$(id -u)/keyring" ]; then
@@ -56,6 +51,11 @@ if [ -d "/run/user/$(id -u)/keyring" ]; then
 
     # Set SSH_AUTH_SOCK to the standard gnome-keyring socket
     export SSH_AUTH_SOCK="/run/user/$(id -u)/keyring/ssh"
+fi
+
+if command -v systemctl >/dev/null; then
+    # set environment variables for new units started by user service manager
+    systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DCONF_PROFILE SSH_AUTH_SOCK
 fi
 
 # Run cosmic-session


### PR DESCRIPTION
Move the systemctl import-environment call after keyring setup so the SSH_AUTH_SOCK variable exists before being imported into the user service manager. Remove the earlier duplicate import block.