### PR TITLE
Add missing mark_as_not_cloexec calls to panel and notification sockets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use async_signals::Signals;
 use color_eyre::{Result, eyre::WrapErr};
 use cosmic_notifications_util::{DAEMON_NOTIFICATIONS_FD, PANEL_NOTIFICATIONS_FD};
 use futures_util::StreamExt;
+use process::mark_as_not_cloexec;
 #[cfg(feature = "autostart")]
 use itertools::Itertools;
 use launch_pad::{ProcessManager, process::Process};
@@ -271,6 +272,10 @@ async fn start(
 
 	let (panel_notifications_fd, daemon_notifications_fd) =
 		notifications::create_socket().expect("Failed to create notification socket");
+
+	mark_as_not_cloexec(&panel_notifications_fd).expect("Failed to mark panel fd as not cloexec");
+	mark_as_not_cloexec(&daemon_notifications_fd)
+		.expect("Failed to mark daemon fd as not cloexec");
 
 	let mut daemon_env_vars = env_vars.clone();
 	daemon_env_vars.push((


### PR DESCRIPTION
The notifications applet is failing to display in the panel. Seeing this error in journalctl:

```
Jan 05 10:26:22 pop-os cosmic-panel[34618]: Failed to get fd for the notifications applet I/O error: socket closed
Jan 05 10:26:22 pop-os cosmic-session[3592]: 2026-01-05T15:26:22.951967Z ERROR cosmic_notifications::subscriptions::notifications: Failed to create connection Failed to create the dbus server
Jan 05 10:26:22 pop-os cosmic-notifications[34669]: Failed to create connection Failed to create the dbus server
Jan 05 10:26:22 pop-os cosmic-session[3592]: restarted process ' DISPLAY=:1 WAYLAND_DISPLAY=wayland-1 XDG_SESSION_TYPE=wayland GTK_MODULES=gail:atk-bridge QT_ACCESSIBILITY=1 QTWEBENGINE_DICTIONARIES_PATH=/usr/share/hunspell-bdic/ GSM_SKIP_SSH_AGENT_WORKAROUND=true DAEMON_NOTIFICATIONS_FD=23 cosmic-notifications ', now at 2 restarts
```

Attempting to run the final line (`DISPLAY=:1 WAYLAND_DISPLAY=wayland-1 XDG_SESSION_TYPE=wayland GTK_MODULES=gail:atk-bridge QT_ACCESSIBILITY=1 QTWEBENGINE_DICTIONARIES_PATH=/usr/share/hunspell-bdic/ GSM_SKIP_SSH_AGENT_WORKAROUND=true DAEMON_NOTIFICATIONS_FD=23 cosmic-notifications`) manually fails with the following output:

```
Failed to create connection task 15 panicked with message "called `Result::unwrap()
` on an `Err` value: Os { code: 9, kind: Uncategorized, message: \"Bad file descriptor\" }"
```

Looking at where these FDs are created, it looks like the CLOEXEC flag needs to unset so they aren't killed after being exec'd by cosmic-session.

This likely fixes https://github.com/pop-os/cosmic-epoch/issues/1237 and fixes https://github.com/pop-os/cosmic-epoch/issues/1505
