### PR TITLE
fix(debian): remove titlebar-font gsettings key

### DIFF
--- a/debian/cosmic-session.gsettings-override
+++ b/debian/cosmic-session.gsettings-override
@@ -6,4 +6,3 @@ cursor-theme = "Pop"
 font-name = "Open Sans 11"
 document-font-name = "Open Sans 11"
 monospace-font-name = "Noto Sans Mono 11"
-titlebar-font='Open Sans Bold 11'


### PR DESCRIPTION
Fix for this error messages during package upgrades

```
No such key “titlebar-font” in schema “org.gnome.desktop.interface:COSMIC” as specified in override file “/usr/share/glib-2.0/schemas/10_cosmic-session.gschema.override”; ignoring override for this key.
```

The pop-desktop package also has gsettings overrides with these keys that will need to be removed.