### PR TITLE
start-cosmic: update values of existing env vars

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -54,8 +54,26 @@ if [ -d "/run/user/$(id -u)/keyring" ]; then
 fi
 
 if command -v systemctl >/dev/null; then
-    # set environment variables for new units started by user service manager
+    # Import some variables that we explicitly want to have available
+    # in the user session.
     systemctl --user import-environment XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DCONF_PROFILE SSH_AUTH_SOCK
+
+    # For environment variables already imported into the user's
+    # session, if the value imported differs from the value in this
+    # environment, update it.
+    existing_env_vars=( $(systemctl --user show-environment | tr '\n' ' ') )
+    for env_var in "${existing_env_vars[@]}"; do
+        env_var_name="$(echo "${env_var}" | awk -F '=' '{print $1}')"
+        env_var_val_str_to_compare="${env_var_name}=${!env_var_name:-}"
+
+        if [[ "${env_var}" != "${env_var_val_str_to_compare}" ]]; then
+            # Update only if the value in current environment is non-empty
+            env_var_unassigned_str="${env_var_name}="
+            if [[ "${env_var_val_str_to_compare}" != "${env_var_unassigned_str}" ]]; then
+                systemctl --user import-environment "${env_var_name}" ||:
+            fi
+        fi
+    done
 fi
 
 # Run cosmic-session


### PR DESCRIPTION
I could not find any consistent documentation on _which_ environment variables a DE should populate. GNOME just imports everything[0] from the current DE-startup-session. KDE imports some DE and KDE specific variables but again, this isn't defined anywhere (that I could find) on places like <freedesktop.org>. So instead, lets just update existing ones.
[0]: https://gitlab.gnome.org/GNOME/gnome-session/-/commit/d14f6db15e9e042cf20799010f31b4ec6b45ed9e