### PR TITLE
Use mapfile to read environment variables

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -67,7 +67,7 @@ if command -v systemctl >/dev/null; then
     # For environment variables already imported into the user's
     # session, if the value imported differs from the value in this
     # environment, update it.
-    existing_env_vars=( $(systemctl --user show-environment | tr '\n' ' ') )
+    mapfile -t existing_env_vars < <(systemctl --user show-environment)
     for env_var in "${existing_env_vars[@]}"; do
         env_var_name="$(echo "${env_var}" | awk -F '=' '{print $1}')"
         env_var_val_str_to_compare="${env_var_name}=${!env_var_name:-}"


### PR DESCRIPTION
Looping with `tr '\n' ' '` would break if variables contain whitespace.

I'm also not too sure that checking the values is correct: systemd returns the values as ANSI-C quoted (`$''`) strings if needed, which will always differ from the unquoted string in the current environment variable.

This could be solved by just checking if the environment variable is defined and importing it into the systemd environment based on that. (Maybe even limit it to non-empty values, not sure what the best approach would be.)

I can create a new issue for the above or add an extra commit to this PR, whatever you prefer.