### PR TITLE
start-cosmic: skip invalid environment variable names

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -70,6 +70,12 @@ if command -v systemctl >/dev/null; then
     existing_env_vars=( $(systemctl --user show-environment | tr '\n' ' ') )
     for env_var in "${existing_env_vars[@]}"; do
         env_var_name="$(echo "${env_var}" | awk -F '=' '{print $1}')"
+
+	# Skip invalid bash variable names (systemd allows names bash does not)
+	if ! [[ "${env_var_name}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+	    continue
+	fi
+
         env_var_val_str_to_compare="${env_var_name}=${!env_var_name:-}"
 
         if [[ "${env_var}" != "${env_var_val_str_to_compare}" ]]; then


### PR DESCRIPTION
This PR fixes a crash in start-cosmic when systemd user environment
contains variables that are not valid Bash identifiers.

Such variables cause indirect expansion to fail, preventing the
COSMIC session from starting.

This change skips invalid variable names before using indirect
expansion.

Related to pop-os/cosmic-epoch#3114