### PR TITLE
fix: don't overwrite QT_QPA_PLATFORMTHEME, add old qt5ct compatibility

### DIFF
--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -39,17 +39,19 @@ export QT_ENABLE_HIGHDPI_SCALING=1
 export DCONF_PROFILE=cosmic
 
 # Set the QT platform theme to CuteCosmic. Fallback to qt6ct if CuteCosmic is not installed.
-export QT_QPA_PLATFORMTHEME=cosmic
-for QT_PLUGIN_PATH in /usr/lib{*,/*}/qt6/plugins; do
-    if [ -f "${QT_PLUGIN_PATH}/platformthemes/libcutecosmictheme.so" ]; then
-        # CuteCosmic found, no need for a fallback.
-        export QT_QPA_PLATFORMTHEME=cosmic
-        break
-    elif [ -f "${QT_PLUGIN_PATH}/platformthemes/libqt6ct.so" ]; then
-        # Fallback to qt6ct, but keep looking for CuteCosmic.
-        export QT_QPA_PLATFORMTHEME=qt6ct
-    fi
-done
+if [ -z "$QT_QPA_PLATFORMTHEME" ]; then
+    export QT_QPA_PLATFORMTHEME=cosmic
+    for QT_PLUGIN_PATH in /usr/lib{*,/*}/qt6/plugins; do
+        if [ -f "${QT_PLUGIN_PATH}/platformthemes/libcutecosmictheme.so" ]; then
+            # CuteCosmic found, no need for a fallback.
+            export QT_QPA_PLATFORMTHEME=cosmic
+            break
+        elif [ -f "${QT_PLUGIN_PATH}/platformthemes/libqt6ct.so" ]; then
+            # Fallback to qt6ct, but keep looking for CuteCosmic.
+            export QT_QPA_PLATFORMTHEME=qt6ct
+        fi
+    done
+fi
 
 # Start gnome keyring components if the daemon is active
 # -> check if /run/user/$UID/keyring exists

--- a/data/start-cosmic
+++ b/data/start-cosmic
@@ -46,9 +46,10 @@ if [ -z "$QT_QPA_PLATFORMTHEME" ]; then
             # CuteCosmic found, no need for a fallback.
             export QT_QPA_PLATFORMTHEME=cosmic
             break
-        elif [ -f "${QT_PLUGIN_PATH}/platformthemes/libqt6ct.so" ]; then
+        elif [ -f "${QT_PLUGIN_PATH}/platformthemes/libqt6ct.so" ] || [ -f "${QT_PLUGIN_PATH}/platformthemes/libqt5ct.so" ]; then
             # Fallback to qt6ct, but keep looking for CuteCosmic.
-            export QT_QPA_PLATFORMTHEME=qt6ct
+            # Note that "qt5ct" is compatible with both qt5ct and qt6ct.
+            export QT_QPA_PLATFORMTHEME=qt5ct
         fi
     done
 fi


### PR DESCRIPTION
This lets you set QT_QPA_PLATFORMTHEME in ~/.profile if you need to.

#### Context

I have cutecosmic installed but I wanted to switch back to qt6ct due to this bug: https://github.com/IgKh/cutecosmic/issues/19.

I tried setting `QT_QPA_PLATFORMTHEME` in `~/.profile` and `~/.bashrc` but they didn't work for GUI apps. Turns out this change was needed to stop cosmic-session overwriting my `~/.profile`'s value.

***

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

