### PR TITLE
Fix FD leak

### DIFF
--- a/src/comp.rs
+++ b/src/comp.rs
@@ -105,7 +105,10 @@ pub fn run_compositor(
 	// Create a pair of unix sockets - one for us (session),
 	// one for the compositor (comp)
 	let (session, comp) = UnixStream::pair().wrap_err("failed to create pair of unix sockets")?;
-	let (mut session_rx, _session_tx) = session.into_split();
+	let (mut session_rx, session_tx) = session.into_split();
+	// Drop the write half immediately — session never writes to the compositor
+	// via this socket, and holding it open would prevent EOF on the comp side.
+	drop(session_tx);
 	// Convert our compositor socket to a non-blocking file descriptor.
 	let comp = {
 		let std_stream = comp
@@ -145,6 +148,13 @@ pub fn run_compositor(
 			)
 			.await
 			.expect("failed to launch compositor");
+
+		// Drop the compositor-side fd now that the child process has inherited it.
+		// Without this, the parent keeps the comp socket endpoint alive, preventing
+		// EOF on session_rx when the child exits — causing the IPC loop to hang
+		// forever and blocking session restart.
+		drop(comp);
+
 		// Create a new state object for IPC purposes.
 		let mut ipc_state = IpcState {
 			env_tx: Some(env_tx),

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,11 +145,22 @@ async fn start(
 	)
 	.wrap_err("failed to start compositor")?;
 
-	let mut env_vars = env_rx
-		.await
-		.expect("failed to receive environmental variables")
-		.into_iter()
-		.collect::<Vec<_>>();
+	let mut env_vars =
+		match tokio::time::timeout(Duration::from_secs(30), env_rx).await {
+			Ok(Ok(vars)) => vars.into_iter().collect::<Vec<_>>(),
+			Ok(Err(_)) => {
+				error!("compositor exited before sending environment variables");
+				compositor_handle.abort();
+				return Ok(Status::Restarted);
+			}
+			Err(_) => {
+				error!(
+					"timed out waiting for environment variables from compositor (30s)"
+				);
+				compositor_handle.abort();
+				return Ok(Status::Restarted);
+			}
+		};
 	info!(
 		"got environmental variables from cosmic-comp: {:?}",
 		env_vars


### PR DESCRIPTION
comp.rs — FD leak (root cause):
drop(session_tx) (line 108-110): The write half of the session socket was held open as _session_tx for the entire task lifetime. Dropped immediately since session never writes to the compositor.

drop(comp) (line 151-156): The compositor-side OwnedFd was captured by the async move block and kept alive after start_process returned. The child inherits the fd, but the parent's copy kept the socket endpoint alive — so when the child crashed, session_rx.read_exact() never got EOF, the IPC loop hung forever, env_tx was never sent, and the entire session deadlocked. Now dropped immediately after spawn.

main.rs — Timeout + graceful restart (defense in depth)  
replaced .expect() with timeout + match: env_rx.await.expect(...) would panic (crashing the session) if the compositor died before sending env vars. Now:
    - 30-second timeout catches GPU driver hangs
    - Err from the oneshot catches compositor crash before SetEnv
    - Both paths abort the compositor task and return Status::Restarted, triggering the session restart loop

Likely fixes https://github.com/pop-os/cosmic-panel/issues/381