### PR TITLE
fix: increase open file limit for dbus-broker

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -47,6 +47,9 @@ install:
     # mimeapps
     install -Dm0644 data/cosmic-mimeapps.list {{ applicationdir }}/cosmic-mimeapps.list
 
+    # dbus-broker hardening: raise soft fd limit and enable restart on failure
+    install -Dm0644 data/dbus-broker.service.d/10-cosmic-nofile.conf {{ systemddir }}/dbus-broker.service.d/10-cosmic-nofile.conf
+
     # dconf profile
     install -Dm644 data/dconf/profile/cosmic {{ rootdir }}/{{ cosmic_dconf_profile }}
 

--- a/data/dbus-broker.service.d/10-cosmic-nofile.conf
+++ b/data/dbus-broker.service.d/10-cosmic-nofile.conf
@@ -1,0 +1,4 @@
+[Service]
+Restart=on-failure
+RestartSec=1
+LimitNOFILE=524288:1048576


### PR DESCRIPTION
I'm not sure if this is desired but here's the situation:

- If dbus-broker dies everything goes crazy (test it if you don't mind restarting your pc: `pkill -f dbus-broker`).
- Looks like from up-stream "restart" is set to false for dbus-broker, so if it crashes, it doesn't come back. It used to make sense since if it goes away, every client needs to re-establish their connection. Some of cosmic-apps don't. Some do, we can fix that. But as far as I know newer apps (even gtk ones) recover if they lose their dbus connection. So, restarting the dbus-broker shouldn't be a big deal. It may silently leave some apps in a bad state though.
- Currently the open file limit for dbus-broker is 1024!
- If we have a bunch of clients, it's easy to reach that number, if we reach that number dbus-broker crashes, becomes a zombie, systemd doesn't restart it. We die!

This PR adds a config file to increase the open file limit for dbus-broker, and also restart it on failure.

There are more fixes that need to happen across all COSMIC apps to avoid infinite loops if the dbus-broker crashes, and proper reconnection. I'll be opening those PRs later, but I'm curious if you guys are OK with this first step. If it makes sense? and if I understood the issue correctly.

Relevant mattermost chat: https://chat.pop-os.org/pop-os/pl/fdazztbf9igj88kfp7iqccbrco

____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

