### PR TITLE
fix(debian): seatd conflict causes Ctrl+C to kill the session

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Homepage: https://github.com/pop-os/cosmic-session
 
 Package: cosmic-session
 Architecture: amd64 arm64
+Conflicts: seatd
 Depends:
   ${misc:Depends},
   ${shlibs:Depends},


### PR DESCRIPTION
Add it as a conflict since it conflicts with systemd-logind.

- https://github.com/pop-os/cosmic-epoch/issues/2026
- https://github.com/pop-os/cosmic-session/issues/205

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

