### PR TITLE
Pass `env_vars` to `cosmic-settings-daemon`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -229,6 +229,7 @@ async fn start(
 		.start(
 			Process::new()
 				.with_executable("cosmic-settings-daemon")
+				.with_env(env_vars.iter().cloned())
 				.with_on_stdout(move |_, _, line| {
 					let stdout_span = stdout_span.clone();
 					async move {


### PR DESCRIPTION
This is needed for `cosmic-settings-daemon` to be able to use Wayland.

Required for https://github.com/pop-os/cosmic-settings-daemon/pull/153. Though passing the env vars here seems reasonable in general, and without that change is harmless and should have no impact.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

