### PR TITLE
Add version argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-session"
-version = "1.0.0"
+version = "1.8.0"
 dependencies = [
  "color-eyre",
  "cosmic-dbus-a11y",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmic-session"
 description = "The session manager for the COSMIC desktop environment"
-version = "1.0.0"
+version = "1.8.0"
 license = "GPL-3.0-only"
 edition = "2024"
 rust-version = "1.93"

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,13 @@ const ENVIRONMENT_NAME: &'static str = "COSMIC";
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
+	if let Some(arg) = env::args().nth(1)
+		&& (arg == "--version" || arg == "-V")
+	{
+		println!("cosmic-session {}", env!("CARGO_PKG_VERSION"));
+		return Ok(());
+	}
+
 	color_eyre::install().wrap_err("failed to install color_eyre error handler")?;
 
 	let trace = tracing_subscriber::registry();

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,13 @@ async fn start(
 	env_vars.push(("XDG_SESSION_TYPE".to_string(), "wayland".to_string()));
 	systemd::set_systemd_environment("XDG_SESSION_TYPE", "wayland").await;
 
+	// expose the session version
+	env_vars.push((
+		"COSMIC_VERSION".to_string(),
+		env!("CARGO_PKG_VERSION").to_string(),
+	));
+	systemd::set_systemd_environment("COSMIC_VERSION", env!("CARGO_PKG_VERSION")).await;
+
 	#[cfg(feature = "systemd")]
 	let _inhibit_fd = if *is_systemd_used() {
 		match get_systemd_env().await {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Since I saw that cosmic-session will be added to the version update script, it's probably the best place for external stuff (e.g. fastfetch) to fetch the COSMIC version from.

Closes https://github.com/pop-os/cosmic-epoch/issues/3692

Edit: Also sets the `COSMIC_VERSION` env var, as mentioned in https://github.com/pop-os/cosmic-comp/issues/2425.